### PR TITLE
meta viewport tag added in src/index.html for responsive body width support in chrome

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <link rel="icon" href="/favicon.png" type="image/png">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>My Awesome App</title>
   </head>
   <body>


### PR DESCRIPTION
While Responsiveness of flex code which includes `@media` property firefox seems to detect the viewpo while inspecting for small devices in developer tools but google chrome shows the default viewport length 980 for `window.innerWidth` . with the line 

`<meta name="viewport" content="width=device-width, initial-scale=1">`

chrome wont scaling width according to device. The same problem exists in android mobile browsers . I think the boilerplate should include the meta tag for responsiveness in index.html